### PR TITLE
Update javascript MIME type

### DIFF
--- a/shusd.c
+++ b/shusd.c
@@ -318,7 +318,7 @@ static const char *get_type(const magic_t mag, const char *url)
 			return "text/css";
 
 		if (0 == strcmp("js", ext))
-			return "text/javascript";
+			return "application/javascript";
 	}
 
 	return magic_file(mag, url);


### PR DESCRIPTION
According to RFC 4329 (https://tools.ietf.org/html/rfc4329#section-7) the "text/javascript" MIME type is obsolete, the MIME "application/javascript" should be used instead.